### PR TITLE
Fix super accel speed buff display.

### DIFF
--- a/2.05-custom-gx/buff.hsp
+++ b/2.05-custom-gx/buff.hsp
@@ -528,7 +528,7 @@
 	if ( calcbuff_buffid == BUFF_SPEED ) {
 		locvar_calcbuff_p = limit(50 + calcbuff_power / 10, 1, 800)
 		dur = 8 + calcbuff_power / 20
-		if ( calcbuff_charid == CHARA_PLAYER ) {
+		if ( calcbuff_charid == CHARA_PLAYER | (calcbuff_charid == -2 & tc == CHARA_PLAYER) ) {
 			if ( cdata(CDATA_MATERIAL2_COUNTER, CHARA_PLAYER) == 1 ) {
 				locvar_calcbuff_p = locvar_calcbuff_p * 13 / 10
 			}


### PR DESCRIPTION
This fixes the stock E+ issue where the speed buff display in the profile doesn't match the higher value that the super accel feat gives. When displaying info about the buff for a profile, calcbuff_charid is set to -2 and tc is set to the character whose profile is being viewed.