### PR TITLE
(Fix) Reimplenting drink mechanic with Cargo Food (With tweak condition included)

### DIFF
--- a/2.05-custom-gx/proc.hsp
+++ b/2.05-custom-gx/proc.hsp
@@ -5108,6 +5108,14 @@
 	if ( synccheck(cc, -1) ) {
 		txt lang(npcn(cc) + itemname(ci, 1) + "を食べ終えた。", name(cc) + " " + have(cc) + " finished eating " + itemname(ci, 1) + ".")
 	}
+	if ( TweakData(TWEAK_GAMEPLAY_CG_DISABLE_THIRST, TWEAK_CATEGORY_GAMEPLAY) == FALSE ) {
+		if ( cdata(CDATA_THIRST, cc) < 12000 ) {
+			if ( synccheck(cc, -1) ) {
+				txt lang("さらに、付属していた飲み物も飲んだ。", name(cc) + " also drank the beverage that came with the food.")
+			}
+			cdata(CDATA_THIRST, cc) += 2000
+		}
+	}
 
     /********** ORIGINAL - BEGINNING ********** // Remove thirst mechanic.
 

--- a/2.05-custom-gx/proc.hsp
+++ b/2.05-custom-gx/proc.hsp
@@ -5108,7 +5108,7 @@
 	if ( synccheck(cc, -1) ) {
 		txt lang(npcn(cc) + itemname(ci, 1) + "を食べ終えた。", name(cc) + " " + have(cc) + " finished eating " + itemname(ci, 1) + ".")
 	}
-	if ( TweakData(TWEAK_GAMEPLAY_CG_DISABLE_THIRST, TWEAK_CATEGORY_GAMEPLAY) == FALSE ) {
+	if ( refitem(inv(INV_ITEM_ID, ci), DBSPEC_CARGO) == 1 & TweakData(TWEAK_GAMEPLAY_CG_DISABLE_THIRST, TWEAK_CATEGORY_GAMEPLAY) == FALSE) {
 		if ( cdata(CDATA_THIRST, cc) < 12000 ) {
 			if ( synccheck(cc, -1) ) {
 				txt lang("さらに、付属していた飲み物も飲んだ。", name(cc) + " also drank the beverage that came with the food.")
@@ -5116,20 +5116,6 @@
 			cdata(CDATA_THIRST, cc) += 2000
 		}
 	}
-
-    /********** ORIGINAL - BEGINNING ********** // Remove thirst mechanic.
-
-	if ( refitem(inv(INV_ITEM_ID, ci), DBSPEC_CARGO) == 1 ) {
-		if ( cdata(CDATA_THIRST, cc) < 12000 ) {
-			if ( synccheck(cc, -1) ) {
-				txt lang("さらに、付属していた飲み物も飲んだ。", name(cc) + " also drank the beverage that came with the food.")
-			}
-			cdata(CDATA_THIRST, cc) += 2000
-		}
-	}
-
-     ********** ORIGINAL - ENDING **********/
-
 	gosub *insta_eat
 	rowactend cc
 	return


### PR DESCRIPTION
In Elona+ there is a thirst quenching mechanic when eating cargo food both manually and automatically on the world map.
However, the mechanic is completely commented out when eating cargo food manually - I assume this is just a small oversight in the battle between removing and re-implementing the thirst mechanic. This fix allows cargo food to quench thirst again and includes the condition check for the tweak `TWEAK_GAMEPLAY_CG_DISABLE_THIRST`. 