### PR TITLE
(New Tweak) Increased Variety of Hireable Home Servants

### DIFF
--- a/2.05-custom-gx/custom_tweaks.hsp
+++ b/2.05-custom-gx/custom_tweaks.hsp
@@ -47,6 +47,7 @@ TweakData(63, 2) = "(Custom-G) Apply damage calculation buffs."
 TweakData(64, 2) = "Summoned monster training."
 TweakData(65, 2) = "No stamina depletion when using stairs in Your Home."
 TweakData(66, 2) = "Increased limit to daily pet arena match attempts."
+TweakData(67, 2) = "Increased variety of hireable home servants."
 
 TweakData(x, 3) = "AI Tweaks"
 TweakData(0, 3) = "Change Zeome's AI."
@@ -471,7 +472,7 @@ TweakData(51, 4) = "Disable cicada noises."
     cs = 0
     page = 0
     pagesize = 16
-    listmax = 25
+    listmax = 26
 *GameplayTweakMenu_pgchk
 	redraw 0
 	page_check
@@ -506,7 +507,8 @@ TweakData(51, 4) = "Disable cicada noises."
 	listn(0, 21) = "Summoned monster training." + GetTStatus(TWEAK_CATEGORY_GAMEPLAY, TWEAK_GAMEPLAY_SUMMONED_MONSTER_TRAINING)
 	listn(0, 22) = "No stamina depletion when using stairs in Your Home." + GetTStatus(TWEAK_CATEGORY_GAMEPLAY, TWEAK_GAMEPLAY_HOME_STAIRS_NO_STAMINA_USAGE)
 	listn(0, 23) = "Increased daily Pet Arena attempts. " + GetTStatus(TWEAK_CATEGORY_GAMEPLAY, TWEAK_GAMEPLAY_PET_ARENA_INCREASED_MATCH_LIMIT)
-	listn(0, 24) = "Return"
+	listn(0, 24) = "Increased variety of hireable home servants." + GetTStatus(TWEAK_CATEGORY_GAMEPLAY, TWEAK_GAMEPLAY_MORE_HIREABLE_HOUSE_SERVANTS)
+	listn(0, 25) = "Return"
 
 	font lang(cfg_font1, cfg_font2), 14 - en * 2, 0
 
@@ -600,9 +602,12 @@ TweakData(51, 4) = "Disable cicada noises."
 				s = "Using stairs in Your Home will not deplete stamina."
 			}
 			if ( p == 23 ) {
-				s = "Increases the daily limit to Pet Arena match attempts\nin intervals of 10 and maxing out at 100 a day."
+				s = "Increases the daily limit of Pet Arena match attempts\nin intervals of 10 and maxing out at 100 a day."
 			}
 			if ( p == 24 ) {
+				s = "Adds more hireable home servants.\nIncludes the baker, fisher, and food vendor.\nAlso increases the number of servants generated."
+			}
+			if ( p == 25 ) {
 				s = "Return to the previous menu."
 			}
 			pos wx + 38, wy + 343
@@ -745,6 +750,11 @@ TweakData(51, 4) = "Disable cicada noises."
 		gosub *IncrementTweak
 	}
 	if ( p == 24 ) {
+		tc = TWEAK_CATEGORY_GAMEPLAY
+		tn = TWEAK_GAMEPLAY_MORE_HIREABLE_HOUSE_SERVANTS
+		gosub *ToggleTweak
+	}
+	if ( p == 25 ) {
 		snd SOUNDLIST_OK1
         return
 	}
@@ -1072,4 +1082,3 @@ TweakData(51, 4) = "Disable cicada noises."
 	}
 	goto *ai_followMove
 	return
-

--- a/2.05-custom-gx/defines/mod.hsp
+++ b/2.05-custom-gx/defines/mod.hsp
@@ -1319,7 +1319,7 @@
 #define global	EFFECT_CHAOS_FRAGMENT	124
 
 ; NOTE: Due to a bug in (non-Custom) Elona+, the effect ID
-; for memory converters is undefined, so the socks effect 
+; for memory converters is undefined, so the socks effect
 ; in non-Custom's code is 125 when it should have been 126.
 #define global	EFFECT_MEMORY_CONVERTER	125
 #define global	EFFECT_SOCKS2	126
@@ -1720,41 +1720,41 @@
 #define global	ITEM_STATUS_BLESSED	1
 
 // Potioman Names
-#define global	POTIOMAN_NAME_SPINNING	1 
-#define global	POTIOMAN_NAME_MIGHTY	2 
-#define global	POTIOMAN_NAME_DUAL	3 
-#define global	POTIOMAN_NAME_RAPID	4 
-#define global	POTIOMAN_NAME_SNIPE	5 
-#define global	POTIOMAN_NAME_DECEIVE	6 
+#define global	POTIOMAN_NAME_SPINNING	1
+#define global	POTIOMAN_NAME_MIGHTY	2
+#define global	POTIOMAN_NAME_DUAL	3
+#define global	POTIOMAN_NAME_RAPID	4
+#define global	POTIOMAN_NAME_SNIPE	5
+#define global	POTIOMAN_NAME_DECEIVE	6
 
-#define global	POTIOMAN_SUBNAME_BIHORN	2 
-#define global	POTIOMAN_SUBNAME_KNIMAIL	3 
-#define global	POTIOMAN_SUBNAME_DRAGOUL	4 
-#define global	POTIOMAN_SUBNAME_FOXAIL	5 
-#define global	POTIOMAN_SUBNAME_LEOHEART	6 
-#define global	POTIOMAN_SUBNAME_STAGITO	7 
-#define global	POTIOMAN_SUBNAME_WYVERNG	8 
-#define global	POTIOMAN_SUBNAME_PEGATHER	9 
-#define global	POTIOMAN_SUBNAME_VALKSPEAR	10 
-#define global	POTIOMAN_SUBNAME_GRIFEAK	11 
-#define global	POTIOMAN_SUBNAME_FLAENIX	12 
-#define global	POTIOMAN_SUBNAME_GOLEDY	13 
-#define global	POTIOMAN_SUBNAME_SOLDIGUN	14 
-#define global	POTIOMAN_SUBNAME_WOLFANG	15 
-#define global	POTIOMAN_SUBNAME_DEATRANIUM	16 
-#define global	POTIOMAN_SUBNAME_KOBOLORD	17 
-#define global	POTIOMAN_SUBNAME_ORFIN	18 
-#define global	POTIOMAN_SUBNAME_BUSHILADE	19 
-#define global	POTIOMAN_SUBNAME_GIGANOOT	20 
-#define global	POTIOMAN_SUBNAME_LEVIASCALE	21 
-#define global	POTIOMAN_SUBNAME_OGREAND	22 
-#define global	POTIOMAN_SUBNAME_BEARM	23 
-#define global	POTIOMAN_SUBNAME_CERBEADS	24 
-#define global	POTIOMAN_SUBNAME_HERCUREST	25 
-#define global	POTIOMAN_SUBNAME_TIGELAW	26 
-#define global	POTIOMAN_SUBNAME_DINOGUTS	27 
-#define global	POTIOMAN_SUBNAME_RAVRAIN	28 
-#define global	POTIOMAN_SUBNAME_IFHEAT	30 
+#define global	POTIOMAN_SUBNAME_BIHORN	2
+#define global	POTIOMAN_SUBNAME_KNIMAIL	3
+#define global	POTIOMAN_SUBNAME_DRAGOUL	4
+#define global	POTIOMAN_SUBNAME_FOXAIL	5
+#define global	POTIOMAN_SUBNAME_LEOHEART	6
+#define global	POTIOMAN_SUBNAME_STAGITO	7
+#define global	POTIOMAN_SUBNAME_WYVERNG	8
+#define global	POTIOMAN_SUBNAME_PEGATHER	9
+#define global	POTIOMAN_SUBNAME_VALKSPEAR	10
+#define global	POTIOMAN_SUBNAME_GRIFEAK	11
+#define global	POTIOMAN_SUBNAME_FLAENIX	12
+#define global	POTIOMAN_SUBNAME_GOLEDY	13
+#define global	POTIOMAN_SUBNAME_SOLDIGUN	14
+#define global	POTIOMAN_SUBNAME_WOLFANG	15
+#define global	POTIOMAN_SUBNAME_DEATRANIUM	16
+#define global	POTIOMAN_SUBNAME_KOBOLORD	17
+#define global	POTIOMAN_SUBNAME_ORFIN	18
+#define global	POTIOMAN_SUBNAME_BUSHILADE	19
+#define global	POTIOMAN_SUBNAME_GIGANOOT	20
+#define global	POTIOMAN_SUBNAME_LEVIASCALE	21
+#define global	POTIOMAN_SUBNAME_OGREAND	22
+#define global	POTIOMAN_SUBNAME_BEARM	23
+#define global	POTIOMAN_SUBNAME_CERBEADS	24
+#define global	POTIOMAN_SUBNAME_HERCUREST	25
+#define global	POTIOMAN_SUBNAME_TIGELAW	26
+#define global	POTIOMAN_SUBNAME_DINOGUTS	27
+#define global	POTIOMAN_SUBNAME_RAVRAIN	28
+#define global	POTIOMAN_SUBNAME_IFHEAT	30
 
 
 // Inventory operations
@@ -6849,6 +6849,7 @@
 #define global	TWEAK_GAMEPLAY_SUMMONED_MONSTER_TRAINING	64
 #define global	TWEAK_GAMEPLAY_HOME_STAIRS_NO_STAMINA_USAGE	65
 #define global  TWEAK_GAMEPLAY_PET_ARENA_INCREASED_MATCH_LIMIT 66
+#define global	TWEAK_GAMEPLAY_MORE_HIREABLE_HOUSE_SERVANTS 67
 
 #define global	TWEAK_AI_ZEOME	0
 #define global	TWEAK_AI_INCREASED_PARTYTIME_DRUNKENNESS 1

--- a/2.05-custom-gx/map_user.hsp
+++ b/2.05-custom-gx/map_user.hsp
@@ -1421,11 +1421,11 @@
 			goto *com_home_SWEND1
 		}
 		moreHireableHomeServants = 0
-		if ( TweakData(TWEAK_GAMEPLAY_MORE_HIREABLE_HOUSE_SERVANTS, TWEAK_CATEGORY_GAMEPLAY == TRUE){
+		if ( TweakData(TWEAK_GAMEPLAY_MORE_HIREABLE_HOUSE_SERVANTS, TWEAK_CATEGORY_GAMEPLAY) == TRUE ) {
 			moreHireableHomeServants = 3
 		}
 		repeat 10 + (moreHireableHomeServants * 2)
-			randomize gdata(GDATA_DAY) + cnt
+			randomize gdata(GDATA_DAY) + gdata(GDATA_MONTH) * 31 + cnt
 			if ( rnd(2) ) {
 				continue
 			}
@@ -1437,7 +1437,7 @@
 			}
 			dbid = isethire(hire)
 
-			randomize gdata(GDATA_DAY) + cnt
+			randomize gdata(GDATA_DAY) + gdata(GDATA_MONTH) * 31 + cnt
 			flt 20
 			characreate -1, dbid, -3, 0
 			if ( stat == 0 ) {
@@ -1447,38 +1447,38 @@
 			cdata(CDATA_ROLE, rc) = isethirerole(hire)
 			if ( cdata(CDATA_ID, rc) == CREATURE_ID_SHOPKEEPER ) {
 				p = rnd(6 + moreHireableHomeServants)
-				if ( p == 0 | p == 4) {
+				if ( p == 0 | p == 4 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_ARMOR
-					cdatan(CDATAN_NAME, rc) = lang("武具店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of armory")
+					snarmor cdatan(CDATAN_NAME, rc)
 				}
 				if ( p == 1 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_GENERAL
-					cdatan(CDATAN_NAME, rc) = lang("雑貨屋の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of general store")
+					sngeneral cdatan(CDATAN_NAME, rc)
 				}
 				if ( p == 2 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_MAGIC
-					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of magic store")
+					snmagic cdatan(CDATAN_NAME, rc)
 				}
 				if ( p == 3 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_GOODS
-					cdatan(CDATAN_NAME, rc) = lang("何でも屋の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of goods store")
+					sngoods cdatan(CDATAN_NAME, rc)
 				}
 				if ( p == 5 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_BLACKMARKET
-					cdatan(CDATAN_NAME, rc) = lang("ブラックマーケットの" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of blackmarket")
+					snblack cdatan(CDATAN_NAME, rc)
 				}
 				if ( p == 6 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_BAKERY
-					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of baker store")
-					cdata(CDATA_PIC, rc) = xy2pic(6, 4) //Baker sprite, otherwise looks like normal merchant.	
+					snbakery cdatan(CDATAN_NAME, rc)
+					cdata(CDATA_PIC, rc) = xy2pic(6, 4) // Baker sprite
 				}
 				if ( p == 7 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_FOOD
-					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " the food vendor")
+					snfood cdatan(CDATAN_NAME, rc)
 				}
 				if ( p == 8 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_FISH
-					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " the fisher")
+					snfish cdatan(CDATAN_NAME, rc)
 				}
 				randomize
 				cdata(CDATA_ROLE_SHOP_LEVEL, rc) = rnd(15) + 1

--- a/2.05-custom-gx/map_user.hsp
+++ b/2.05-custom-gx/map_user.hsp
@@ -1420,7 +1420,11 @@
 			txt lang("家はすでに人であふれかえっている。", "You already have too many guests in your home.")
 			goto *com_home_SWEND1
 		}
-		repeat 10
+		moreHireableHomeServants = 0
+		if ( TweakData(TWEAK_GAMEPLAY_MORE_HIREABLE_HOUSE_SERVANTS, TWEAK_CATEGORY_GAMEPLAY == TRUE){
+			moreHireableHomeServants = 3
+		}
+		repeat 10 + (moreHireableHomeServants * 2)
 			randomize gdata(GDATA_DAY) + cnt
 			if ( rnd(2) ) {
 				continue
@@ -1442,8 +1446,8 @@
 			cdata(CDATA_EXIST, rc) = CHAR_STATE_TEMP
 			cdata(CDATA_ROLE, rc) = isethirerole(hire)
 			if ( cdata(CDATA_ID, rc) == CREATURE_ID_SHOPKEEPER ) {
-				p = rnd(6)
-				if ( p == 0 ) {
+				p = rnd(6 + moreHireableHomeServants)
+				if ( p == 0 | p == 4) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_ARMOR
 					cdatan(CDATAN_NAME, rc) = lang("武具店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of armory")
 				}
@@ -1459,13 +1463,22 @@
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_GOODS
 					cdatan(CDATAN_NAME, rc) = lang("何でも屋の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of goods store")
 				}
-				if ( p == 4 ) {
-					cdata(CDATA_ROLE, rc) = ROLE_SHOP_ARMOR
-					cdatan(CDATAN_NAME, rc) = lang("武具店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of armory")
-				}
 				if ( p == 5 ) {
 					cdata(CDATA_ROLE, rc) = ROLE_SHOP_BLACKMARKET
 					cdatan(CDATAN_NAME, rc) = lang("ブラックマーケットの" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of blackmarket")
+				}
+				if ( p == 6 ) {
+					cdata(CDATA_ROLE, rc) = ROLE_SHOP_BAKERY
+					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " of baker store")
+					cdata(CDATA_PIC, rc) = xy2pic(6, 4) //Baker sprite, otherwise looks like normal merchant.	
+				}
+				if ( p == 7 ) {
+					cdata(CDATA_ROLE, rc) = ROLE_SHOP_FOOD
+					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " the food vendor")
+				}
+				if ( p == 8 ) {
+					cdata(CDATA_ROLE, rc) = ROLE_SHOP_FISH
+					cdatan(CDATAN_NAME, rc) = lang("魔法店の" + cdatan(CDATAN_NAME, rc), cdatan(CDATAN_NAME, rc) + " the fisher")
 				}
 				randomize
 				cdata(CDATA_ROLE_SHOP_LEVEL, rc) = rnd(15) + 1


### PR DESCRIPTION
Hiya, so this is a tweak for adding the fisher, baker, and food vendor as hireable home servants.
Just small things to note: 

1. The original `repeat 10` changed to `repeat 10 + (moreHireableHomeServants * 2)` is 1/2 the number of times it creates hire-able servants so I increased it a bit to account for new servant variety. 

2. I merged the `p == 0` and `p == 4` blocks since they're duplicates so now `p == 0 | p == 4`

Don't need to worry about calculating hiring cost because their `ROLE` is within the same range as `MERCHANT`