### PR TITLE
(Brainstorm) Tweaking Shop Stock

### DIFF
--- a/2.05-custom-gx/chat.hsp
+++ b/2.05-custom-gx/chat.hsp
@@ -22885,9 +22885,10 @@
 		inv(INV_ITEM_NUM, cnt) = 0
 	loop
 	p = 40 + cdata(CDATA_ROLE_SHOP_LEVEL, tc) * 2 / 3
-	if ( p > 120 ) {
-		p = 120
+	if ( p > 200 ) {
+		p = 200
 	}
+	p += int(sdata(SKILL_NORMAL_NEGOTIATION, CHARA_PLAYER)/50)
 	if ( cdata(CDATA_ROLE, tc) == ROLE_SHOP_BLACKMARKET ) {
 		p = 7 + limit(cdata(CDATA_ROLE_SHOP_LEVEL, tc) / 7, 1, 30)
 	}


### PR DESCRIPTION
Hiya - so I wanted to toss this idea your way since an issue that has come up is game pacing - and some things in original Elona(or Elona+, whichever came first) aren't scaled for the faster-paced gameplay.

So let's start small and I wanted to get your opinion on possibly adjusting the cap on items by merchants. The biggest issue here is that currently, magic vendors are MVP because of their scrolls of wonder. They sell roughly 3-5 at a time at Rank 60. However, once they're invested to the cap of 140, they will intentionally sell barely 2 at a time because they're over-riden by high objective level items such spellbooks of 4th-Dimension. 

And of course with the Yacatect God, and how negotiation drops off entirely at roughly Lv. 70, I was looking for a way to make them more relevant and more scaled.

Again, all brainstorming - just wanted your opinion. 