### PR TITLE
(Fix) Adding newline after artifact creation

### DIFF
--- a/2.05-custom-gx/item.hsp
+++ b/2.05-custom-gx/item.hsp
@@ -2189,14 +2189,14 @@
 					ii_p = inv_getowner(ci)
 					if ( ii_p != (-1) ) {
 						if ( cdata(CDATA_ROLE, ii_p) == ROLE_ADVENTURER ) {
-							artifactlocation += lang(iknownnameref(inv(INV_ITEM_ID, ci)) + "は" + gdata(GDATA_YEAR) + "年" + gdata(GDATA_MONTH) + "月に" + mapname(cdata(CDATA_AREA, ii_p)) + "の" + cdatan(CDATAN_NAME, ii_p) + "の手に渡った。\n", cnven(iknownnameref(inv(INV_ITEM_ID, ci))) + " was held by " + cdatan(CDATAN_NAME, ii_p) + " at " + mapname(cdata(CDATA_AREA, ii_p)) + " in " + gdata(GDATA_DAY) + "/" + gdata(GDATA_MONTH) + ", " + gdata(GDATA_YEAR) + ". ")
+							artifactlocation += lang(iknownnameref(inv(INV_ITEM_ID, ci)) + "は" + gdata(GDATA_YEAR) + "年" + gdata(GDATA_MONTH) + "月に" + mapname(cdata(CDATA_AREA, ii_p)) + "の" + cdatan(CDATAN_NAME, ii_p) + "の手に渡った。\n", cnven(iknownnameref(inv(INV_ITEM_ID, ci))) + " was held by " + cdatan(CDATAN_NAME, ii_p) + " at " + mapname(cdata(CDATA_AREA, ii_p)) + " in " + gdata(GDATA_DAY) + "/" + gdata(GDATA_MONTH) + ", " + gdata(GDATA_YEAR) + ".\n")
 						}
 						else {
 							ii_p = -1
 						}
 					}
 					if ( ii_p == (-1) ) {
-						artifactlocation += lang(iknownnameref(inv(INV_ITEM_ID, ci)) + "は" + gdata(GDATA_YEAR) + "年" + gdata(GDATA_MONTH) + "月に" + mdatan(MDATAN_NAME) + "で生成された。\n", cnven(iknownnameref(inv(INV_ITEM_ID, ci))) + " was created at " + mdatan(MDATAN_NAME) + " in " + gdata(GDATA_DAY) + "/" + gdata(GDATA_MONTH) + ", " + gdata(GDATA_YEAR) + ".")
+						artifactlocation += lang(iknownnameref(inv(INV_ITEM_ID, ci)) + "は" + gdata(GDATA_YEAR) + "年" + gdata(GDATA_MONTH) + "月に" + mdatan(MDATAN_NAME) + "で生成された。\n", cnven(iknownnameref(inv(INV_ITEM_ID, ci))) + " was created at " + mdatan(MDATAN_NAME) + " in " + gdata(GDATA_DAY) + "/" + gdata(GDATA_MONTH) + ", " + gdata(GDATA_YEAR) + ".\n")
 					}
 				}
 			}


### PR DESCRIPTION
In Japanese, the game newlines after writing/displaying an artifact in the `art.txt` or when using Oracle spell/scroll - the English version doesn't. This fixes that. 