### PR TITLE
Making custom map names show up on the world map

### DIFF
--- a/2.05-custom-gx/map_user.hsp
+++ b/2.05-custom-gx/map_user.hsp
@@ -643,13 +643,19 @@
 		gosub *prompt_word
 		if ( inputlog == "" ) {
 			txt lang("名前をつけるのはやめた。", "You changed your mind.")
-			adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 0
+			//adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 0
 		}
 		else {
 			mdatan(MDATAN_NAME) = "" + inputlog
+            // Immediately save the new name to the corresponding tmp file so it can be read when leaving the map
+            folder = exedir + "tmp\\"
+            file = folder + "mdatan_" + gdata(GDATA_AREA) + "_" + (100 + gdata(GDATA_LEVEL)) + ".s2"
+            fmode = "mdatan"
+            fread = 0
+            arrayfilewrapper
 			adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 9999
-			txt lang("" + mdatan(MDATAN_NAME) + "という名前で呼ぶことにした。", "You named " + him(tc) + " " + cdatan(CDATAN_NAME, tc) + ".")
-			gosub *screen_refreshFull
+            gosub *screen_refreshFull
+			txt lang("" + mdatan(MDATAN_NAME) + "という名前で呼ぶことにした。", "You named it " + mdatan(MDATAN_NAME) + ".")
 		}
 		gosub *screen_refresh
 		goto *pc_turn

--- a/2.05-custom-gx/text.hsp
+++ b/2.05-custom-gx/text.hsp
@@ -2687,6 +2687,19 @@
 			s += lang("《覚醒》", "Awaken")
 		}
 	}
+    if ( adata(ADATA_FESTIVAL, mapname_mapid) == 9999 ) {
+        exist exedir + "tmp\\" + "mdatan_" + mapname_mapid + "_101.s2"
+        if ( strsize == (-1) ) {
+            exist exedir + "save\\" + playerid + "\\mdatan_" + mapname_mapid + "_101.s2"
+            if ( strsize != (-1) ) {    
+                noteload exedir + "save\\" + playerid + "\\mdatan_" + mapname_mapid + "_101.s2"
+            }
+        }
+        else {
+            noteload exedir + "tmp\\" + "mdatan_" + mapname_mapid + "_101.s2"
+        }
+        noteget s, 0
+    }
 	if ( mapname_arg2 == 1 ) {
 		if ( adata(ADATA_ID, mapname_mapid) == AREA_SISTER_MANSION | adata(ADATA_ID, mapname_mapid) == AREA_OBLIVION_PALACE | (gdata(GDATA_FLAG_SUB_BEYOND_THE_GENERATIONS) < 8 & adata(ADATA_ID, mapname_mapid) == AREA_IRMA_THALIA_WORKSHOP) ) {
 			return ""


### PR DESCRIPTION
Currently, giving buildings custom names doesn't actually make their name show up on the overworld map, and in some other instances like leaving the map. This makes it so that when you rename something the new name shows up all the time. e.g. naming a shop Snail-Mart and walking over it will show "You see Snail-Mart." instead of "You see Shop."

`adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 0` is commented out in `map_user.hsp` because that causes unwanted behavior when canceling from the rename screen, and has no purpose otherwise. `ADATA_FESTIVAL` was already set to 9999 whenever the player gave a map a custom name, in this code that's being used to detect if a map was custom-named, basically.

There's also a small fix(?) where the "You named it [name]" is put after the `screen_refreshFull` so the player actually sees it, and a botched copypasta probably from the creature renaming code was fixed to show the new map name.
