### PR TITLE
QoL tweaks for pet prostitutes

### DIFF
--- a/2.05-custom-gx/ai.hsp
+++ b/2.05-custom-gx/ai.hsp
@@ -1431,9 +1431,14 @@
 						}
 						if ( dist(cdata(CDATA_X, cc), cdata(CDATA_Y, cc), cdata(CDATA_X, cnt), cdata(CDATA_Y, cnt)) < 6 ) {
 							if ( fov_los(cdata(CDATA_X, cc), cdata(CDATA_Y, cc), cdata(CDATA_X, cnt), cdata(CDATA_Y, cnt)) ) {
-								cdata(CDATA_TARGET, cc) = cnt
-								tc = cnt
-								break
+								if ( cc < MAX_CHARA_FOLLOWER & cdata(CDATA_GOLD, cnt) <= 0 ) {
+									continue
+								}
+								else {
+									cdata(CDATA_TARGET, cc) = cnt
+									tc = cnt
+									break
+								}
 							}
 						}
 					loop

--- a/2.05-custom-gx/map_user.hsp
+++ b/2.05-custom-gx/map_user.hsp
@@ -643,13 +643,19 @@
 		gosub *prompt_word
 		if ( inputlog == "" ) {
 			txt lang("名前をつけるのはやめた。", "You changed your mind.")
-			adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 0
+			//adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 0
 		}
 		else {
 			mdatan(MDATAN_NAME) = "" + inputlog
+            // Immediately save the new name to the corresponding tmp file so it can be read when leaving the map
+            folder = exedir + "tmp\\"
+            file = folder + "mdatan_" + gdata(GDATA_AREA) + "_" + (100 + gdata(GDATA_LEVEL)) + ".s2"
+            fmode = "mdatan"
+            fread = 0
+            arrayfilewrapper
 			adata(ADATA_FESTIVAL, gdata(GDATA_AREA)) = 9999
-			txt lang("" + mdatan(MDATAN_NAME) + "という名前で呼ぶことにした。", "You named " + him(tc) + " " + cdatan(CDATAN_NAME, tc) + ".")
-			gosub *screen_refreshFull
+            gosub *screen_refreshFull
+			txt lang("" + mdatan(MDATAN_NAME) + "という名前で呼ぶことにした。", "You named it " + mdatan(MDATAN_NAME) + ".")
 		}
 		gosub *screen_refresh
 		goto *pc_turn

--- a/2.05-custom-gx/proc.hsp
+++ b/2.05-custom-gx/proc.hsp
@@ -3108,6 +3108,10 @@
 		}
 		else {
 			cdata(CDATA_GOLD, cc) += sexvalue
+			if ( cc < MAX_CHARA_FOLLOWER ) {
+                txt lang(name(cc) + "は" + sexvalue + "gp稼いだ。", name(cc) + " earned " + sexvalue + "gp.")
+                snd SOUNDLIST_GETGOLD1
+            }
 		}
 	}
 	rowactend cc
@@ -3225,6 +3229,10 @@
 		}
 		else {
 			cdata(CDATA_GOLD, cc) += sexvalue
+			if ( cc < MAX_CHARA_FOLLOWER ) {
+                txt lang(name(cc) + "は" + sexvalue + "gp稼いだ。", name(cc) + " earned " + sexvalue + "gp.")
+                snd SOUNDLIST_GETGOLD1
+            }
 		}
 	}
 	rowactend cc

--- a/2.05-custom-gx/text.hsp
+++ b/2.05-custom-gx/text.hsp
@@ -2687,6 +2687,19 @@
 			s += lang("《覚醒》", "Awaken")
 		}
 	}
+    if ( adata(ADATA_FESTIVAL, mapname_mapid) == 9999 ) {
+        exist exedir + "tmp\\" + "mdatan_" + mapname_mapid + "_101.s2"
+        if ( strsize == (-1) ) {
+            exist exedir + "save\\" + playerid + "\\mdatan_" + mapname_mapid + "_101.s2"
+            if ( strsize != (-1) ) {    
+                noteload exedir + "save\\" + playerid + "\\mdatan_" + mapname_mapid + "_101.s2"
+            }
+        }
+        else {
+            noteload exedir + "tmp\\" + "mdatan_" + mapname_mapid + "_101.s2"
+        }
+        noteget s, 0
+    }
 	if ( mapname_arg2 == 1 ) {
 		if ( adata(ADATA_ID, mapname_mapid) == AREA_SISTER_MANSION | adata(ADATA_ID, mapname_mapid) == AREA_OBLIVION_PALACE | (gdata(GDATA_FLAG_SUB_BEYOND_THE_GENERATIONS) < 8 & adata(ADATA_ID, mapname_mapid) == AREA_IRMA_THALIA_WORKSHOP) ) {
 			return ""


### PR DESCRIPTION
I decided to catch a prostitute as a pet and found that it kept "working" while it was in my party. I made a few QoL tweaks for them.

1. When pets earn money from prostitution, a sound effect will play and the log will show how much they earned. Just to give an idea of what's happening and how much money your pet is making.
2. Pets will no longer prostitute themselves to targets with 0 gold. Since this is simply a waste of time. And it rarely happens anyway, except when you sit near an NPC and rest/read/etc for a long time and they get whored at on repeat. So really it just reduces log spam and stops them from repeatedly dancing around and pissing themselves for no reason.

Only pets are altered by this, normal prostitutes and the unique NPC with their behavior will act exactly the same