### PR TITLE
QoL tweaks for pet prostitutes

### DIFF
--- a/2.05-custom-gx/ai.hsp
+++ b/2.05-custom-gx/ai.hsp
@@ -1431,21 +1431,26 @@
 						}
 						if ( dist(cdata(CDATA_X, cc), cdata(CDATA_Y, cc), cdata(CDATA_X, cnt), cdata(CDATA_Y, cnt)) < 6 ) {
 							if ( fov_los(cdata(CDATA_X, cc), cdata(CDATA_Y, cc), cdata(CDATA_X, cnt), cdata(CDATA_Y, cnt)) ) {
-								cdata(CDATA_TARGET, cc) = cnt
-								tc = cnt
-								break
+								if ( cc < MAX_CHARA_FOLLOWER & cdata(CDATA_GOLD, cnt) <= 0 ) {
+									continue
+								}
+								else {
+									cdata(CDATA_TARGET, cc) = cnt
+									tc = cnt
+									break
+								}
 							}
 						}
 					loop
 				}
 				if ( cc < MAX_CHARA_FOLLOWER ) {
 					if ( cdata(CDATA_TARGET, cc) != 0 ) {
-						if ( synccheck(cc, -1) ) {
-							if ( synccheck(tc, -1) ) {
-								txt lang(cdatan(CDATAN_NAME, cc) + "は" + cdatan(CDATAN_NAME, tc) + "を狙っている…。", cdatan(CDATAN_NAME, cc) + " seems to be aiming at " + cdatan(CDATAN_NAME, tc) + "...")
-							}
-						}
-					}
+                    	if ( synccheck(cc, -1) ) {
+                            if ( synccheck(tc, -1) ) {
+                                txt lang(cdatan(CDATAN_NAME, cc) + "は" + cdatan(CDATAN_NAME, tc) + "を狙っている…。", cdatan(CDATAN_NAME, cc) + " seems to be aiming at " + cdatan(CDATAN_NAME, tc) + "...")
+                            }
+                        }
+                    }
 				}
 				distance = dist(cdata(CDATA_X, tc), cdata(CDATA_Y, tc), cdata(CDATA_X, cc), cdata(CDATA_Y, cc))
 				if ( tc != CHARA_PLAYER ) {

--- a/2.05-custom-gx/proc.hsp
+++ b/2.05-custom-gx/proc.hsp
@@ -3108,6 +3108,10 @@
 		}
 		else {
 			cdata(CDATA_GOLD, cc) += sexvalue
+			if ( cc < MAX_CHARA_FOLLOWER ) {
+                txt lang(name(cc) + "は" + sexvalue + "gp稼いだ。", name(cc) + " earned " + sexvalue + "gp.")
+                snd SOUNDLIST_GETGOLD1
+            }
 		}
 	}
 	rowactend cc
@@ -3225,6 +3229,10 @@
 		}
 		else {
 			cdata(CDATA_GOLD, cc) += sexvalue
+			if ( cc < MAX_CHARA_FOLLOWER ) {
+                txt lang(name(cc) + "は" + sexvalue + "gp稼いだ。", name(cc) + " earned " + sexvalue + "gp.")
+                snd SOUNDLIST_GETGOLD1
+            }
 		}
 	}
 	rowactend cc


### PR DESCRIPTION
I decided to catch a prostitute as a pet and found that it kept "working" while it was in my party. I made a few QoL tweaks for them.

1. When pets earn money from prostitution, a sound effect will play and the log will show how much they earned. Just to give an idea of what's happening and how much money your pet is making.
2. Pets will no longer prostitute themselves to targets with 0 gold. Since this is simply a waste of time. And it rarely happens anyway, except when you sit near an NPC and rest/read/etc for a long time and they get whored at on repeat. So really it just reduces log spam and stops them from repeatedly dancing around and pissing themselves for no reason.

Only pets are altered by this, normal prostitutes and the unique NPC with their behavior will act exactly the same