### PR TITLE
Fix game crashes caused by crazy-theatre

### DIFF
--- a/2.05-custom-gx/chara_func.hsp
+++ b/2.05-custom-gx/chara_func.hsp
@@ -5679,12 +5679,12 @@
 		if ( cdata(CDATA_CONDITION_ANGRY, dmghp_source) > 0 ) {
 			locvar_dmghp_dmg *= 2
 		}
-	}
 		if ( cdata(CDATA_FRIENDSHIP, CHARA_PLAYER) == 5 ) {
 			if ( locvar_dmghp_dmg >= 100 ) {
 				locvar_dmghp_dmg = locvar_dmghp_dmg / 100 * (100 + limit(cdata(CDATA_SANITY, dmghp_source), 0, 100))
 			}
 		}
+	}
 	if ( cdata(CDATA_DIRECTIVE_MODE, dmghp_charid) == DIRECTIVE_MODE_DEFENSIVE ) {
 		locvar_dmghp_dmg = locvar_dmghp_dmg / 3
 	}


### PR DESCRIPTION
Game crashes when trying to reduce damage without source like bleed.
chara_func.hsp line 5684